### PR TITLE
Remove unnecessary utf-8 header in license_headers.py (follow-up to #…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Changed
 ### Deprecated
 ### Removed
-- Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615))
+- Removed unnecessary `# -*- coding: utf-8 -*-` headers from .py files ([#615](https://github.com/opensearch-project/opensearch-py/pull/615), [#617](https://github.com/opensearch-project/opensearch-py/pull/617))
 ### Fixed
 ### Security
 

--- a/utils/license_headers.py
+++ b/utils/license_headers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # SPDX-License-Identifier: Apache-2.0
 #
 # The OpenSearch Contributors require contributions made to
@@ -18,7 +17,7 @@ import re
 import sys
 from typing import Iterator, List
 
-LINES_TO_KEEP = ["# -*- coding: utf-8 -*-", "#!/usr/bin/env python"]
+LINES_TO_KEEP = ["#!/usr/bin/env python"]
 
 LICENSE_HEADER = """
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
…615) (#617)

* License tools: remove utf-8 coding declaration from license_headers.py check/fix script; since #615 it is no longer used in the library's codebase

UTF-8 is the default encoding used to read source code files for Python3 - see https://docs.python.org/3/howto/unicode.html#unicode-literals-in-python-source-code



* Cleanup: remove utf-8 coding declaration from the license_headers.py script itself



* Update CHANGELOG.md



---------